### PR TITLE
load data file as an inputStream as File can't be loaded from jar

### DIFF
--- a/src/main/java/uk/gov/ons/fsdr/adeccomock/EmployeeInitializer.java
+++ b/src/main/java/uk/gov/ons/fsdr/adeccomock/EmployeeInitializer.java
@@ -8,9 +8,9 @@ import org.springframework.stereotype.Component;
 import uk.gov.ons.fsdr.adeccomock.dto.Device;
 import uk.gov.ons.fsdr.adeccomock.dto.Employee;
 
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.List;
 
 @Component
@@ -32,16 +32,16 @@ public class EmployeeInitializer implements CommandLineRunner {
   }
 
   private List<Device> getDevicesFromCsv() throws IOException {
-    File file = deviiceFile.getFile();
-    return (List<Device>) new CsvToBeanBuilder(new FileReader(file))
+    InputStream file = deviiceFile.getInputStream();
+    return new CsvToBeanBuilder<Device>(new InputStreamReader(file))
         .withType(Device.class)
         .build()
         .parse();
   }
 
   private List<Employee> getEmployeesFromCsv() throws IOException {
-    File file = employeeFile.getFile();
-    return (List<Employee>) new CsvToBeanBuilder(new FileReader(file))
+    InputStream file = employeeFile.getInputStream();
+    return new CsvToBeanBuilder<Employee>(new InputStreamReader(file))
         .withType(Employee.class)
         .build()
         .parse();


### PR DESCRIPTION
the mock was failing to deploy in kubernetes as it was failing to find the data files in the jar when converting the resource to a File, this has now been changed to use an inputstream as this works for resources in the jar