### PR TITLE
sort returned employees based on employee id

### DIFF
--- a/src/main/java/uk/gov/ons/fsdr/adeccomock/managers/ResponseManager.java
+++ b/src/main/java/uk/gov/ons/fsdr/adeccomock/managers/ResponseManager.java
@@ -27,7 +27,7 @@ public class ResponseManager {
   }
 
   public List<AdeccoResponse> getAllResponses() {
-    List<AdeccoResponse>  responses = new ArrayList<AdeccoResponse>();
+    List<AdeccoResponse>  responses = new ArrayList<>();
     Collection<List<AdeccoResponse>> values = responseDirectory.values();
     for (List<AdeccoResponse> list : values) {
       responses.addAll(list);

--- a/src/main/java/uk/gov/ons/fsdr/adeccomock/service/AdeccoMockService.java
+++ b/src/main/java/uk/gov/ons/fsdr/adeccomock/service/AdeccoMockService.java
@@ -11,6 +11,7 @@ import uk.gov.ons.fsdr.common.dto.AdeccoResponse;
 import uk.gov.ons.fsdr.common.dto.AdeccoResponseList;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
@@ -34,6 +35,7 @@ public class AdeccoMockService {
     AdeccoResponseList adeccoResponseList = new AdeccoResponseList();
 
     List<AdeccoResponse> allResponses = getResponses(sql);
+    allResponses.sort(Comparator.comparing((AdeccoResponse aR) -> aR.getAdeccoResponseWorker().getEmployeeId()));
     adeccoResponseList.setRecords(allResponses);
     adeccoResponseList.setTotalSize(String.valueOf(allResponses.size()));
     adeccoResponseList.setNextRecordsUrl("nextRecord");


### PR DESCRIPTION
sort employees returned by adecco mock by their employee id, this has been done as an order by has been added to the query for adecco in the fsdr-service